### PR TITLE
timothy - create database for menu item reviews

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a Menu Item Review
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "MenuItemReviews")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private long itemId;
+  private String reviewEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The MenuItemReviewRepository is a repository for MenuItemReview entities.
+ */
+
+@Repository
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "MenuItemReview-1",
+          "author": "timothytwu",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEW"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEW_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ITEM_ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STARS",
+                      "type": "INT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "MENUITEMREVIEW"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #26 

In this PR, we add a database table that represents MenuItemReviews, with the following fields:

```
Long itemId (the id in the UCSBDiningCommonsMenuItems table of a menu item)
String reviewerEmail (the email of the reviewer)
int stars (0 to 5 stars)
LocalDateTime dateReviewed
String comments
```
You can test this by running on localhost and looking for the MenuItemReviews table on the h2-console

<img width="201" alt="image" src="https://github.com/user-attachments/assets/77a93dea-079e-4bdf-8849-b40b90e7a021" />

You can also test this by running on dokku and connecting to the postgres database and running \dt

```
team01_dev_timothytwu_db=# \dt
                 List of relations
 Schema |         Name          | Type  |  Owner   
--------+-----------------------+-------+----------
 public | databasechangelog     | table | postgres
 public | databasechangeloglock | table | postgres
 public | menuitemreview        | table | postgres
 public | restaurants           | table | postgres
 public | ucsbdates             | table | postgres
 public | ucsbdiningcommons     | table | postgres
 public | users                 | table | postgres
(7 rows)

```
