### PR TITLE
Timothy - create MenuItemReview controller, add GET (index) and POST (create)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -74,7 +74,7 @@ public class MenuItemReviewController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public MenuItemReview postMenuItemReview(
-            @Parameter(name="itemID") @RequestParam int itemID,
+            @Parameter(name="itemID") @RequestParam long itemID,
             @Parameter(name="reviewerEmail") @RequestParam String reviewerEmail,
             @Parameter(name="stars") @RequestParam int stars,
             @Parameter(name="reviewDate") @RequestParam("reviewDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime reviewDate,

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -56,31 +56,20 @@ public class MenuItemReviewController extends ApiController {
         return reviews;
     }
 
-    /**
-     * Get a single date by id
-     * 
-     * @param id the id of the date
-     * @return a UCSBDate
-     */
-    // @Operation(summary= "Get a single date")
-    // @PreAuthorize("hasRole('ROLE_USER')")
-    // @GetMapping("")
-    // public UCSBDate getById(
-    //         @Parameter(name="id") @RequestParam Long id) {
-    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
 
-    //     return ucsbDate;
-    // }
 
-    /**
-     * Create a new menu item review
-     * 
-     * @param quarterYYYYQ  the quarter in the format YYYYQ
-     * @param name          the name of the date
-     * @param localDateTime the date
-     * @return the saved ucsbdate
-     */
+/**
+ * Create a new menu item review.
+ *
+ * @param itemID the ID of the menu item being reviewed
+ * @param reviewerEmail the email of the reviewer
+ * @param stars the number of stars given in the review
+ * @param reviewDate the date and time of the review
+ * @param comments the comments included in the review
+ * @return the saved {@link MenuItemReview}
+ * @throws JsonProcessingException if there is an error processing JSON
+ */
+
     @Operation(summary= "Create a new menu item review")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
@@ -111,47 +100,5 @@ public class MenuItemReviewController extends ApiController {
 
     }
 
-    /**
-     * Delete a UCSBDate
-     * 
-     * @param id the id of the date to delete
-     * @return a message indicating the date was deleted
-     */
-    // @Operation(summary= "Delete a UCSBDate")
-    // @PreAuthorize("hasRole('ROLE_ADMIN')")
-    // @DeleteMapping("")
-    // public Object deleteUCSBDate(
-    //         @Parameter(name="id") @RequestParam Long id) {
-    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
-
-    //     ucsbDateRepository.delete(ucsbDate);
-    //     return genericMessage("UCSBDate with id %s deleted".formatted(id));
-    // }
-
-    /**
-     * Update a single date
-     * 
-     * @param id       id of the date to update
-     * @param incoming the new date
-     * @return the updated date object
-     */
-    // @Operation(summary= "Update a single date")
-    // @PreAuthorize("hasRole('ROLE_ADMIN')")
-    // @PutMapping("")
-    // public UCSBDate updateUCSBDate(
-    //         @Parameter(name="id") @RequestParam Long id,
-    //         @RequestBody @Valid UCSBDate incoming) {
-
-    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
-
-    //     ucsbDate.setQuarterYYYYQ(incoming.getQuarterYYYYQ());
-    //     ucsbDate.setName(incoming.getName());
-    //     ucsbDate.setLocalDateTime(incoming.getLocalDateTime());
-
-    //     ucsbDateRepository.save(ucsbDate);
-
-    //     return ucsbDate;
-    // }
+ 
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,157 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for MenuItemReviews
+ */
+
+@Tag(name = "MenuItemReviews")
+@RequestMapping("/api/menuitemreviews")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+    @Autowired
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    /**
+     * List all menu item reviews
+     * 
+     * @return an iterable of MenuItemReview
+     */
+    @Operation(summary= "List all menu item reviews")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<MenuItemReview> allMenuItemReviews() {
+        Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
+        return reviews;
+    }
+
+    /**
+     * Get a single date by id
+     * 
+     * @param id the id of the date
+     * @return a UCSBDate
+     */
+    // @Operation(summary= "Get a single date")
+    // @PreAuthorize("hasRole('ROLE_USER')")
+    // @GetMapping("")
+    // public UCSBDate getById(
+    //         @Parameter(name="id") @RequestParam Long id) {
+    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
+    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+
+    //     return ucsbDate;
+    // }
+
+    /**
+     * Create a new menu item review
+     * 
+     * @param quarterYYYYQ  the quarter in the format YYYYQ
+     * @param name          the name of the date
+     * @param localDateTime the date
+     * @return the saved ucsbdate
+     */
+    @Operation(summary= "Create a new menu item review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public MenuItemReview postMenuItemReview(
+            @Parameter(name="itemID") @RequestParam int itemID,
+            @Parameter(name="reviewerEmail") @RequestParam String reviewerEmail,
+            @Parameter(name="stars") @RequestParam int stars,
+            @Parameter(name="reviewDate") @RequestParam("reviewDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime reviewDate,
+            @Parameter(name="comments") @RequestParam String comments)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("dateReviewed={}", reviewDate);
+
+        MenuItemReview menuItemReview = new MenuItemReview();
+        menuItemReview.setItemId(itemID);
+        menuItemReview.setReviewerEmail(reviewerEmail);
+        menuItemReview.setStars(stars);
+        menuItemReview.setDateReviewed(reviewDate);
+        menuItemReview.setComments(comments);
+        menuItemReview.setDateReviewed(reviewDate);
+
+        MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
+        return savedMenuItemReview;
+        
+
+    }
+
+    /**
+     * Delete a UCSBDate
+     * 
+     * @param id the id of the date to delete
+     * @return a message indicating the date was deleted
+     */
+    // @Operation(summary= "Delete a UCSBDate")
+    // @PreAuthorize("hasRole('ROLE_ADMIN')")
+    // @DeleteMapping("")
+    // public Object deleteUCSBDate(
+    //         @Parameter(name="id") @RequestParam Long id) {
+    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
+    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+
+    //     ucsbDateRepository.delete(ucsbDate);
+    //     return genericMessage("UCSBDate with id %s deleted".formatted(id));
+    // }
+
+    /**
+     * Update a single date
+     * 
+     * @param id       id of the date to update
+     * @param incoming the new date
+     * @return the updated date object
+     */
+    // @Operation(summary= "Update a single date")
+    // @PreAuthorize("hasRole('ROLE_ADMIN')")
+    // @PutMapping("")
+    // public UCSBDate updateUCSBDate(
+    //         @Parameter(name="id") @RequestParam Long id,
+    //         @RequestBody @Valid UCSBDate incoming) {
+
+    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
+    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
+
+    //     ucsbDate.setQuarterYYYYQ(incoming.getQuarterYYYYQ());
+    //     ucsbDate.setName(incoming.getName());
+    //     ucsbDate.setLocalDateTime(incoming.getLocalDateTime());
+
+    //     ucsbDateRepository.save(ucsbDate);
+
+    //     return ucsbDate;
+    // }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -103,7 +103,7 @@ public class MenuItemReviewController extends ApiController {
         menuItemReview.setStars(stars);
         menuItemReview.setDateReviewed(reviewDate);
         menuItemReview.setComments(comments);
-        menuItemReview.setDateReviewed(reviewDate);
+        // menuItemReview.setDateReviewed(reviewDate);
 
         MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
         return savedMenuItemReview;

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -20,8 +20,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "MenuItemReviews")
-@Table(name = "MENUITEMREVIEW")
+@Entity(name = "MENUITEMREVIEW")
+// @Table(name = "MENUITEMREVIEW")
 public class MenuItemReview {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,12 +21,13 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @Entity(name = "MenuItemReviews")
+@Table(name = "MENUITEMREVIEW")
 public class MenuItemReview {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
   private long itemId;
-  private String reviewEmail;
+  private String reviewerEmail;
   private int stars;
   private LocalDateTime dateReviewed;
   private String comments;

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsTests.java
@@ -48,103 +48,98 @@ public class MenuItemReviewsTests extends ControllerTestCase {
     @MockBean
     UserRepository userRepository;
 
-
     // Authorization tests for /api/menuitemreviews/admin/all
 
     @Test
     public void logged_out_users_cannot_get_all() throws Exception {
-            mockMvc.perform(get("/api/menuitemreviews/all"))
-                            .andExpect(status().is(403)); // logged out users can't get all
+        mockMvc.perform(get("/api/menuitemreviews/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
     }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void logged_in_users_can_get_all() throws Exception {
-            mockMvc.perform(get("/api/menuitemreviews/all"))
-                            .andExpect(status().is(200)); // logged
+        mockMvc.perform(get("/api/menuitemreviews/all"))
+                .andExpect(status().is(200)); // logged
     }
 
-
     // Authorization tests for /api/menuitemreviews/post
-        // (Perhaps should also have these for put and delete)
+    // (Perhaps should also have these for put and delete)
 
-        @Test
-        public void logged_out_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/menuitemreviews/post"))
-                                .andExpect(status().is(403));
-        }
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/menuitemreviews/post"))
+                .andExpect(status().is(403));
+    }
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void logged_in_regular_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/menuitemreviews/post"))
-                                .andExpect(status().is(403)); // only admins can post
-        }
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/menuitemreviews/post"))
+                .andExpect(status().is(403)); // only admins can post
+    }
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_menuitemreviews() throws Exception {
 
-                // arrange
-                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+        // arrange
+        LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
-                MenuItemReview menuItemReview1 = MenuItemReview.builder()
-                                .itemId(0)
-                                .reviewerEmail("John Doe")
-                                .stars(0)
-                                .dateReviewed(ldt1)
-                                .comments("This is a test comment")
-                                .build();
+        MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                .itemId(1)
+                .reviewerEmail("John Doe")
+                .stars(1)
+                .dateReviewed(ldt1)
+                .comments("This is a test comment")
+                .build();
 
+        ArrayList<MenuItemReview> expectedMenuItemReview = new ArrayList<>();
+        expectedMenuItemReview.add(menuItemReview1);
 
-                ArrayList<MenuItemReview> expectedMenuItemReview = new ArrayList<>();
-                expectedMenuItemReview.add(menuItemReview1);
+        when(menuItemReviewRepository.findAll()).thenReturn(expectedMenuItemReview);
 
-                when(menuItemReviewRepository.findAll()).thenReturn(expectedMenuItemReview);
+        // act
+        MvcResult response = mockMvc.perform(get("/api/menuitemreviews/all"))
+                .andExpect(status().isOk()).andReturn();
 
-                // act
-                MvcResult response = mockMvc.perform(get("/api/menuitemreviews/all"))
-                                .andExpect(status().isOk()).andReturn();
+        // assert
 
-                // assert
+        verify(menuItemReviewRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedMenuItemReview);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 
-                verify(menuItemReviewRepository, times(1)).findAll();
-                String expectedJson = mapper.writeValueAsString(expectedMenuItemReview);
-                String responseString = response.getResponse().getContentAsString();
-                assertEquals(expectedJson, responseString);
-        }
-        
-        @WithMockUser(roles = { "ADMIN", "USER" })
-        @Test
-        public void an_admin_user_can_post_a_new_ucsbmenuitemreview() throws Exception {
-                // arrange
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_ucsbmenuitemreview() throws Exception {
+        // arrange
 
-                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+        LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
-                MenuItemReview menuItemReview1 = MenuItemReview.builder()
-                                .itemId(0)
-                                .reviewerEmail("John Doe")
-                                .stars(0)
-                                .dateReviewed(ldt1)
-                                .comments("This is a test comment")
-                                .build();
+        MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                .itemId(1)
+                .reviewerEmail("John Doe")
+                .stars(1)
+                .dateReviewed(ldt1)
+                .comments("This is a test comment")
+                .build();
 
-                when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+        when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
 
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/menuitemreviews/post?itemID=1&reviewerEmail=John Doe&stars=1&reviewDate=2022-01-03T00:00:00&comments=This is a test comment")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
 
-                // act
-                MvcResult response = mockMvc.perform(
-                                post("/api/menuitemreviews/post?itemID=0&reviewerEmail=John Doe&stars=0&reviewDate=2022-01-03T00:00:00&comments=This is a test comment")
-                                                .with(csrf()))
-                                .andExpect(status().isOk()).andReturn();
+        // assert
 
-                // assert
-                verify(menuItemReviewRepository, times(1)).save(eq(menuItemReview1));
-                String expectedJson = mapper.writeValueAsString(menuItemReview1);
-                String responseString = response.getResponse().getContentAsString();
-                assertEquals(expectedJson, responseString);
-        }
-
-    
+        verify(menuItemReviewRepository, times(1)).save(eq(menuItemReview1));
+        String expectedJson = mapper.writeValueAsString(menuItemReview1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsTests.java
@@ -1,0 +1,150 @@
+
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewsTests extends ControllerTestCase {
+
+    @MockBean
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+
+    // Authorization tests for /api/menuitemreviews/admin/all
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/menuitemreviews/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/menuitemreviews/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+
+    // Authorization tests for /api/menuitemreviews/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/menuitemreviews/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/menuitemreviews/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                                .itemId(0)
+                                .reviewerEmail("John Doe")
+                                .stars(0)
+                                .dateReviewed(ldt1)
+                                .comments("This is a test comment")
+                                .build();
+
+
+                ArrayList<MenuItemReview> expectedMenuItemReview = new ArrayList<>();
+                expectedMenuItemReview.add(menuItemReview1);
+
+                when(menuItemReviewRepository.findAll()).thenReturn(expectedMenuItemReview);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/menuitemreviews/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(menuItemReviewRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedMenuItemReview);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+        
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_ucsbmenuitemreview() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                                .itemId(0)
+                                .reviewerEmail("John Doe")
+                                .stars(0)
+                                .dateReviewed(ldt1)
+                                .comments("This is a test comment")
+                                .build();
+
+                when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/menuitemreviews/post?itemID=0&reviewerEmail=John Doe&stars=0&reviewDate=2022-01-03T00:00:00&comments=This is a test comment")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(menuItemReviewRepository, times(1)).save(eq(menuItemReview1));
+                String expectedJson = mapper.writeValueAsString(menuItemReview1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+    
+
+}


### PR DESCRIPTION
closes #27 

In this PR, we add a GET and POST for MenuItemReviews. The entity file was also edited so that swagger could access the proper database table. 

<img width="955" alt="Screenshot 2025-04-23 at 5 37 13 PM" src="https://github.com/user-attachments/assets/63c2c5b4-eb36-4c39-8434-f9e3ed617b95" />

Deployed at:
http://team01-dev-timothytwu.dokku-13.cs.ucsb.edu