### PR TITLE
create database table for UCSBDiningCommonsMenuItems

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a UCSBDiningCommonsMenuItem 
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitems")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDateRepository is a repository for UCSBDiningCommonsMenuItem entities.
+ */
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
+
+}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItems-1",
+          "author": "nikunjparasar",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEMS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDININGCOMMONSMENUITEMS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEMS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #8 

In this PR we add a database UCSBDiningCommonsMenuItems  with the following fields

```
String diningCommonsCode
String name
String station
```

You can test this by running on localhost and looking for the UCSBDiningCommonsMenuItems on the H2-console
![image](https://github.com/user-attachments/assets/2fac9880-69bd-40e9-b525-5b69506299c3)

you can also test on dokku by connecting to postgres and looking for the db:

```
nparasar@dokku-13:~$ dokku postgres:connect team01-dev-nikunjparasar-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_nikunjparasar_db=# \dt
                   List of relations
 Schema |            Name            | Type  |  Owner
--------+----------------------------+-------+----------
 public | articles                   | table | postgres
 public | databasechangelog          | table | postgres
 public | databasechangeloglock      | table | postgres
 public | help_request               | table | postgres
 public | menuitemreview             | table | postgres
 public | restaurants                | table | postgres
 public | ucsbdates                  | table | postgres
 public | ucsbdiningcommons          | table | postgres
 public | ucsbdiningcommonsmenuitems | table | postgres
 public | users                      | table | postgres
(10 rows)

team01_dev_nikunjparasar_db=# \q
```