### PR TITLE
timothy-finished delete endpoint for menuItemReviews

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -145,5 +145,23 @@ public class MenuItemReviewController extends ApiController {
         return menuItemReview;
     }
 
+    /**
+     * Delete a menu item review
+     * 
+     * @param id the id of the review to delete
+     * @return a message indicating the review was deleted
+     */
+    @Operation(summary= "Delete a MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id) {
+
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+        menuItemReviewRepository.delete(menuItemReview);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
+
  
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewsTests.java
@@ -283,7 +283,59 @@ public class MenuItemReviewsTests extends ControllerTestCase {
                 verify(menuItemReviewRepository, times(1)).findById(67L);
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("MenuItemReview with id 67 not found", json.get("message"));
+      
+        }
+        // test for delete
 
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_review() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                                .itemId(1)
+                                .reviewerEmail("John Doe")
+                                .stars(1)
+                                .dateReviewed(ldt1)
+                                .comments("This is a test comment")
+                                .build();
+
+                when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(menuItemReview1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/menuitemreviews?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(menuItemReviewRepository, times(1)).findById(15L);
+                verify(menuItemReviewRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_review_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/menuitemreviews?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(menuItemReviewRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 15 not found", json.get("message"));
         }
 
 }


### PR DESCRIPTION
closes #30 

In this PR, we add the delete endpoint for the MenuItemReviews table

<img width="1257" alt="image" src="https://github.com/user-attachments/assets/0a426d74-b31b-4e8b-8dbb-c942f980bbce" />

Deployed at:
http://team01-dev-timothytwu.dokku-13.cs.ucsb.edu
