### PR TITLE
DELETE for UCSBDiningCommonsMenuItems table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsController.java
@@ -127,5 +127,25 @@ public class UCSBDiningCommonsMenuItemsController extends ApiController {
         return ucsbDiningCommonsMenuItem;
     }
 
+	/**
+     * Delete a UCSB Dining Commons Menu Item
+     * 
+     * @param id the id of the menu item to delete
+     * @return a message indicating the menu item was deleted
+     */
+    @Operation(summary= "Delete a UCSBDiningCommonsMenuItem")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBDiningCommonsMenuItem(
+            @Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        ucsbDiningCommonsMenuItemRepository.delete(ucsbDiningCommonsMenuItem);
+        return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
+    }
+
+
+
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsControllerTest.java
@@ -259,7 +259,52 @@ public class UCSBDiningCommonsMenuItemsControllerTest extends ControllerTestCase
 
 	}
 
+	@WithMockUser(roles = { "ADMIN", "USER" })
+	@Test
+	public void admin_can_delete_a_menu_item() throws Exception {
+			// arrange
+
+			UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+				.diningCommonsCode("dlg")
+				.name("cake")
+				.station("bakery")
+				.build();
+
+			when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem1));
+
+			// act
+			MvcResult response = mockMvc.perform(
+							delete("/api/ucsbdiningcommonsmenuitems?id=15")
+											.with(csrf()))
+							.andExpect(status().isOk()).andReturn();
+
+			// assert
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(eq(ucsbDiningCommonsMenuItem1));
+
+			Map<String, Object> json = responseToJson(response);
+			assertEquals("UCSBDiningCommonsMenuItem with id 15 deleted", json.get("message"));
+	}
 
 
+	@WithMockUser(roles = { "ADMIN", "USER" })
+	@Test
+	public void admin_tries_to_delete_non_existant_menu_item_and_gets_right_error_message()
+					throws Exception {
+			// arrange
+
+			when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+			// act
+			MvcResult response = mockMvc.perform(
+							delete("/api/ucsbdiningcommonsmenuitems?id=15")
+											.with(csrf()))
+							.andExpect(status().isNotFound()).andReturn();
+
+			// assert
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+			Map<String, Object> json = responseToJson(response);
+			assertEquals("UCSBDiningCommonsMenuItem with id 15 not found", json.get("message"));
+	}
 
 }


### PR DESCRIPTION
Closes #12 

This PR adds DELETE endpoint for the UCSBDiningCommonsMenuItems table

<img width="1454" alt="image" src="https://github.com/user-attachments/assets/cf5c1885-6b63-4745-96ec-f9df1cebd760" />
