### PR TITLE
Conner - add controller method for DELETE endpoint for UCSBOrganization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -76,4 +76,20 @@ public class UCSBOrganizationController extends ApiController {
 
         return savedOrganization;
     }
+
+    /**
+     * This method returns a single UCSB organization.
+     * @param orgCode orgCode of the UCSB organization
+     * @return a single UCSB organization
+     */
+    @Operation(summary= "Get a single UCSB organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return organization;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -92,4 +92,31 @@ public class UCSBOrganizationController extends ApiController {
 
         return organization;
     }
+
+    /**
+     * Update a single UCSB organization. Accessible only to users with the role "ROLE_ADMIN".
+     * @param orgCode orgCode of the UCSB organization
+     * @param incoming the new UCSB organization contents
+     * @return the updated UCSB organization object
+     */
+    @Operation(summary= "Update a single UCSB organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+
+        organization.setOrgCode(incoming.getOrgCode());  
+        organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        organization.setOrgTranslation(incoming.getOrgTranslation());
+        organization.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(organization);
+
+        return organization;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -119,4 +119,21 @@ public class UCSBOrganizationController extends ApiController {
 
         return organization;
     }
+
+    /**
+     * Delete a UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
+     * @param orgCode orgCode of the organization
+     * @return a message indiciating the organization was deleted
+     */
+    @Operation(summary= "Delete a UCSBOrganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        ucsbOrganizationRepository.delete(organization);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -33,105 +33,160 @@ import static org.mockito.Mockito.when;
 @WebMvcTest(controllers = UCSBOrganizationController.class)
 @Import(TestConfig.class)
 public class UCSBOrganizationControllerTests extends ControllerTestCase {
-    @MockBean
-    UCSBOrganizationRepository ucsbOrganizationRepository;
+        @MockBean
+        UCSBOrganizationRepository ucsbOrganizationRepository;
 
-    @MockBean
-    UserRepository userRepository;
-    // Authorization tests for /api/ucsborganizations/admin/all
+        @MockBean
+        UserRepository userRepository;
+        // Authorization tests for /api/ucsborganizations/admin/all
 
-    @Test
-    public void logged_out_users_cannot_get_all() throws Exception {
-            mockMvc.perform(get("/api/ucsborganizations/all"))
-                            .andExpect(status().is(403)); // logged out users can't get all
-    }
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsborganizations/all"))
+                        .andExpect(status().is(403)); // logged out users can't get all
+        }
 
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void logged_in_users_can_get_all() throws Exception {
-            mockMvc.perform(get("/api/ucsborganizations/all"))
-                            .andExpect(status().is(200)); // logged
-    }
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsborganizations/all"))
+                        .andExpect(status().is(200)); // logged
+        }
 
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void logged_in_user_can_get_all_ucsborganizations() throws Exception {
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsborganizations() throws Exception {
 
-            // arrange
+                // arrange
 
-            UCSBOrganization zpr = UCSBOrganization.builder()
-                            .orgCode("ZPR")
-                            .orgTranslationShort("ZETA PHI RHO")
-                            .orgTranslation("ZETA PHI RHO")
-                            .inactive(false)
-                            .build();
+                UCSBOrganization zpr = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(false)
+                        .build();
 
-            UCSBOrganization sky = UCSBOrganization.builder()
-                            .orgCode("SKY")
-                            .orgTranslationShort("SKYDIVING CLUB")
-                            .orgTranslation("SKYDIVING CLUB AT UCSB")
-                            .inactive(false)
-                            .build();
+                UCSBOrganization sky = UCSBOrganization.builder()
+                        .orgCode("SKY")
+                        .orgTranslationShort("SKYDIVING CLUB")
+                        .orgTranslation("SKYDIVING CLUB AT UCSB")
+                        .inactive(false)
+                        .build();
 
-            ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();
-            expectedOrganizations.addAll(Arrays.asList(zpr, sky));
+                ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();
+                expectedOrganizations.addAll(Arrays.asList(zpr, sky));
 
-            when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
+                when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
 
-            // act
-            MvcResult response = mockMvc.perform(get("/api/ucsborganizations/all"))
-                            .andExpect(status().isOk()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganizations/all"))
+                        .andExpect(status().isOk()).andReturn();
 
-            // assert
+                // assert
 
-            verify(ucsbOrganizationRepository, times(1)).findAll();
-            String expectedJson = mapper.writeValueAsString(expectedOrganizations);
-            String responseString = response.getResponse().getContentAsString();
-            assertEquals(expectedJson, responseString);
-    }
+                verify(ucsbOrganizationRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedOrganizations);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
-    // Authorization tests for /api/ucsbdiningcommons/post
-    // (Perhaps should also have these for put and delete)
+        // Authorization tests for /api/ucsbdiningcommons/post
+        // (Perhaps should also have these for put and delete)
 
-    @Test
-    public void logged_out_users_cannot_post() throws Exception {
-            mockMvc.perform(post("/api/ucsborganizations/post"))
-                            .andExpect(status().is(403));
-    }
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganizations/post"))
+                        .andExpect(status().is(403));
+        }
 
-    @WithMockUser(roles = { "USER" })
-    @Test
-    public void logged_in_regular_users_cannot_post() throws Exception {
-            mockMvc.perform(post("/api/ucsborganizations/post"))
-                            .andExpect(status().is(403)); // only admins can post
-    }
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganizations/post"))
+                        .andExpect(status().is(403)); // only admins can post
+        }
 
-    @WithMockUser(roles = { "ADMIN", "USER" })
-    @Test
-    public void an_admin_user_can_post_a_new_organization() throws Exception {
-            // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_organization() throws Exception {
+                // arrange
 
-            UCSBOrganization zpr = UCSBOrganization.builder()
-                            .orgCode("ZPR")
-                            .orgTranslationShort("ZETA PHI RHO")
-                            .orgTranslation("ZETA PHI RHO")
-                            .inactive(true)
-                            .build();
+                UCSBOrganization zpr = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(true)
+                        .build();
 
-            when(ucsbOrganizationRepository.save(eq(zpr))).thenReturn(zpr);
+                when(ucsbOrganizationRepository.save(eq(zpr))).thenReturn(zpr);
 
-            // act
-            MvcResult response = mockMvc.perform(
-                            post("/api/ucsborganizations/post?orgCode=ZPR&orgTranslationShort=ZETA PHI RHO&orgTranslation=ZETA PHI RHO&inactive=true")
-                                            .with(csrf()))
-                            .andExpect(status().isOk()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(
+                        post("/api/ucsborganizations/post?orgCode=ZPR&orgTranslationShort=ZETA PHI RHO&orgTranslation=ZETA PHI RHO&inactive=true")
+                                        .with(csrf()))
+                        .andExpect(status().isOk()).andReturn();
 
-            // assert
-            verify(ucsbOrganizationRepository, times(1)).save(zpr);
-            String expectedJson = mapper.writeValueAsString(zpr);
-            String responseString = response.getResponse().getContentAsString();
-            assertEquals(expectedJson, responseString);
-    }
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).save(zpr);
+                String expectedJson = mapper.writeValueAsString(zpr);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+    // Tests for GET method
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ucsborganizations?orgCode=ZPR"))
+                        .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                UCSBOrganization organization = UCSBOrganization.builder()
+                        .orgCode("ZPR")
+                        .orgTranslationShort("ZETA PHI RHO")
+                        .orgTranslation("ZETA PHI RHO")
+                        .inactive(true)
+                        .build();
+
+                when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(organization));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganizations?orgCode=ZPR"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("ZPR"));
+                String expectedJson = mapper.writeValueAsString(organization);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("CSU"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganizations?orgCode=CSU"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("CSU"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with orgCode CSU not found", json.get("message"));
+        }
+
 }
     
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -191,7 +191,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_can_edit_an_existing_commons() throws Exception {
+        public void admin_can_edit_an_existing_organization() throws Exception {
                 // arrange
 
                 UCSBOrganization zprOrig = UCSBOrganization.builder()
@@ -230,7 +230,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_cannot_edit_commons_that_does_not_exist() throws Exception {
+        public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
                 // arrange
 
                 UCSBOrganization editedOrganization = UCSBOrganization.builder()
@@ -258,6 +258,54 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("UCSBOrganization with id OSLI not found", json.get("message"));
 
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_an_organization() throws Exception {
+                // arrange
+
+                UCSBOrganization osli = UCSBOrganization.builder()
+                                .orgCode("OSLI")
+                                .orgTranslationShort("STUDENT LIFE")
+                                .orgTranslation("OFFICE OF STUDENT LIFE")
+                                .inactive(false)
+                                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("OSLI"))).thenReturn(Optional.of(osli));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsborganizations?orgCode=OSLI")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("OSLI");
+                verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id OSLI deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_organization_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("KRC"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsborganizations?orgCode=KRC")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("KRC");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id KRC not found", json.get("message"));
         }
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -184,7 +184,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 verify(ucsbOrganizationRepository, times(1)).findById(eq("CSU"));
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("EntityNotFoundException", json.get("type"));
-                assertEquals("UCSBOrganization with orgCode CSU not found", json.get("message"));
+                assertEquals("UCSBOrganization with id CSU not found", json.get("message"));
         }
 
 }


### PR DESCRIPTION
Closes #18 

In this PR, we add the DELETE operation to the UCSB Organization Controller so that we can delete existing organizations.

<img width="557" alt="image" src="https://github.com/user-attachments/assets/11d147cc-bff0-41ab-8838-059dd2bb593f" />


